### PR TITLE
避免一些 CGContext 衍生的問題

### DIFF
--- a/MessageDisplayKit/Classes/Views/MessageContentViews/XHBubblePhotoImageView.m
+++ b/MessageDisplayKit/Classes/Views/MessageContentViews/XHBubblePhotoImageView.m
@@ -15,6 +15,8 @@
 
 @interface XHBubblePhotoImageView ()
 
+@property dispatch_semaphore_t semaphore;
+
 /**
  *  消息类型
  */
@@ -51,6 +53,13 @@
         [self.activityIndicatorView startAnimating];
         [self setImageWithURL:[NSURL URLWithString:thumbnailUrl] placeholer:nil showActivityIndicatorView:NO completionBlock:^(UIImage *image, NSURL *url, NSError *error) {
             if ([url.absoluteString isEqualToString:thumbnailUrl]) {
+
+                if (CGRectEqualToRect(weakSelf.bounds, CGRectZero)) {
+                    weakSelf.semaphore = dispatch_semaphore_create(0);
+                    dispatch_semaphore_wait(weakSelf.semaphore, DISPATCH_TIME_FOREVER);
+                    weakSelf.semaphore = nil;
+                }
+                
                 image = [image thumbnailImage:CGRectGetWidth(weakSelf.bounds) * 2 transparentBorder:0 cornerRadius:0 interpolationQuality:1.0];
                 if (image) {
                     dispatch_async(dispatch_get_main_queue(), ^{
@@ -65,6 +74,9 @@
 
 - (void)setFrame:(CGRect)frame {
     [super setFrame:frame];
+    if (self.semaphore) {
+        dispatch_semaphore_signal(self.semaphore);
+    }
     _activityIndicatorView.center = CGPointMake(CGRectGetWidth(self.bounds) / 2.0, CGRectGetHeight(self.bounds) / 2.0);
 }
 


### PR DESCRIPTION
根據 #130 的討論,

後面還會產生一些相關的 error, 

```
 <Error>: CGContextConcatCTM: invalid context 0x0.
 <Error>: CGContextSetInterpolationQuality: invalid context 0x0.
 <Error>: CGContextDrawImage: invalid context 0x0.
 <Error>: CGBitmapContextCreateImage: invalid context 0x0.
```

仔細追下去的結果很妙, 真正的原因在於 `XHBubblePhotoImageView` 內的 method `configureMessagePhoto:thumbnailUrl:originPhotoUrl:onBubbleMessageType:`, 他裡面有一段 code 原先是這樣的

```
 if (thumbnailUrl) {
    WEAKSELF
    [self addSubview:self.activityIndicatorView];
    [self.activityIndicatorView startAnimating];
    [self setImageWithURL:[NSURL URLWithString:thumbnailUrl] placeholer:nil showActivityIndicatorView:NO completionBlock:^(UIImage *image, NSURL *url, NSError *error) {
        if ([url.absoluteString isEqualToString:thumbnailUrl]) {       
            // A 位置         
            image = [image thumbnailImage:CGRectGetWidth(weakSelf.bounds) * 2 transparentBorder:0 cornerRadius:0 interpolationQuality:1.0];
            if (image) {
                dispatch_async(dispatch_get_main_queue(), ^{
                    weakSelf.messagePhoto = image;
                    [weakSelf.activityIndicatorView stopAnimating];
                });
            }
        }
    }];
}
```

一般沒有發生狀況的時候, A 位置的 bound size 會正常, 不是 {0, 0, 0, 0} 的狀態, 但是如果發生問題的時候, A 位置的 size 就會是 {0, 0, 0, 0}, 繼續 run 則會發生 error, 實際上, 他並不是永遠都是 {0, 0, 0, 0}, 只是因為多線程的關係, `setFrame:` 慢於這邊的處理了, 只要 `setFrame:` 設給他一個新的值之後, 再繼續跑就會是正常, 所以下的解法是用一個 semaphore, 在發生問題的當下卡住線程, 等到被 `setFrame:` 之後再重新運行.

大概是這個樣子, 謝謝.
