### PR TITLE
修正 #153 中提到, 當使用者點擊錄音按鈕立即放開時, 產生 0 秒錄音的問題

### DIFF
--- a/MessageDisplayKit/Classes/Common/XHVoiceRecordHelper.h
+++ b/MessageDisplayKit/Classes/Common/XHVoiceRecordHelper.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+typedef BOOL(^XHPrepareRecorderCompletion)();
 typedef void(^XHStartRecorderCompletion)();
 typedef void(^XHStopRecorderCompletion)();
 typedef void(^XHPauseRecorderCompletion)();
@@ -27,7 +28,8 @@ typedef void(^XHPeakPowerForChannel)(float peakPowerForChannel);
 @property (nonatomic) float maxRecordTime; // 默认 60秒为最大
 @property (nonatomic, readonly) NSTimeInterval currentTimeInterval;
 
-- (void)startRecordingWithPath:(NSString *)path StartRecorderCompletion:(XHStartRecorderCompletion)startRecorderCompletion;
+- (void)prepareRecordingWithPath:(NSString *)path prepareRecorderCompletion:(XHPrepareRecorderCompletion)prepareRecorderCompletion;
+- (void)startRecordingWithStartRecorderCompletion:(XHStartRecorderCompletion)startRecorderCompletion;
 - (void)pauseRecordingWithPauseRecorderCompletion:(XHPauseRecorderCompletion)pauseRecorderCompletion;
 - (void)resumeRecordingWithResumeRecorderCompletion:(XHResumeRecorderCompletion)resumeRecorderCompletion;
 - (void)stopRecordingWithStopRecorderCompletion:(XHStopRecorderCompletion)stopRecorderCompletion;

--- a/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
+++ b/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
@@ -929,10 +929,13 @@ static CGPoint  delayOffset = {0.0};
 
 #pragma mark - Voice Recording Helper Method
 
+- (void)prepareRecordWithCompletion:(XHPrepareRecorderCompletion)completion {
+    [self.voiceRecordHelper prepareRecordingWithPath:[self getRecorderPath] prepareRecorderCompletion:completion];
+}
+
 - (void)startRecord {
     [self.voiceRecordHUD startRecordingHUDAtView:self.view];
-    [self.voiceRecordHelper startRecordingWithPath:[self getRecorderPath] StartRecorderCompletion:^{
-        
+    [self.voiceRecordHelper startRecordingWithStartRecorderCompletion:^{
     }];
 }
 
@@ -1004,6 +1007,11 @@ static CGPoint  delayOffset = {0.0};
     } else {
         [self.messageInputView.inputTextView becomeFirstResponder];
     }
+}
+
+- (void)prepareRecordingVoiceActionWithCompletion:(BOOL (^)(void))completion {
+    DLog(@"prepareRecordingWithCompletion");
+    [self prepareRecordWithCompletion:completion];
 }
 
 - (void)didStartRecordingVoiceAction {

--- a/MessageDisplayKit/Classes/Views/MessageInputView/XHMessageInputView.h
+++ b/MessageDisplayKit/Classes/Views/MessageInputView/XHMessageInputView.h
@@ -56,7 +56,11 @@ typedef NS_ENUM(NSInteger, XHMessageInputViewStyle) {
 - (void)didSelectedMultipleMediaAction;
 
 /**
- *  按下录音按钮开始录音
+ *  按下錄音按鈕 "準備" 錄音
+ */
+- (void)prepareRecordingVoiceActionWithCompletion:(BOOL (^)(void))completion;
+/**
+ *  开始录音
  */
 - (void)didStartRecordingVoiceAction;
 /**


### PR DESCRIPTION
Hello @xhzengAIB,

如討論串中提到的問題, 我這邊修改幾個部分, 從最底層往上說,
將原先 `XHVoiceRecordHelper` 中的

```
 - (void)startRecordingWithPath:(NSString *)path StartRecorderCompletion:(XHStartRecorderCompletion)startRecorderCompletion;
```

拆為兩個 method, 分別是

```
 - (void)prepareRecordingWithPath:(NSString *)path prepareRecorderCompletion:(XHPrepareRecorderCompletion)prepareRecorderCompletion;
 - (void)startRecordingWithStartRecorderCompletion:(XHStartRecorderCompletion)startRecorderCompletion;
```

需要先完成準備, 才可以進行錄音, `XHPrepareRecorderCompletion` 允許上層回傳使用或是取消,
如果上層取消了, 這邊會接回做原先 `cancelledDeleteWithCompletion` 的處置.

往上面一層 `XHMessageTableViewController` 這邊很單純, 所有的 method 感覺只是經過這邊, 所以這邊的變動不大.

最上層的 `XHMessageTextView`, 主要是改原先 `UIControlEventTouchDown` 對應的 method `holdDownButtonTouchDown`, 讓他變成成功的初始化完畢之後, 再運行原有的其他行為.

如果有 coding style 需要修改, 或是覺得哪邊不正常的, 麻煩再不吝告知, 我這邊會再做修正, 謝謝.
