### PR TITLE
增加 insertOldMessages:completion 方法来通知insert 完成，方便实现原子化 insert

### DIFF
--- a/Example/MessageDisplayKitCoreDataExample/MessageDisplayKitCoreDataExample/XHDemoWeChatMessageTableViewController.m
+++ b/Example/MessageDisplayKitCoreDataExample/MessageDisplayKitCoreDataExample/XHDemoWeChatMessageTableViewController.m
@@ -412,8 +412,9 @@
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             NSMutableArray *messages = [weakSelf getTestMessages];
             dispatch_async(dispatch_get_main_queue(), ^{
-                [weakSelf insertOldMessages:messages];
-                weakSelf.loadingMoreMessage = NO;
+                [weakSelf insertOldMessages:messages completion:^{
+                    weakSelf.loadingMoreMessage = NO;
+                }];
             });
         });
     }

--- a/Example/MessageDisplayKitLeanchatExample/MessageDisplayKitLeanchatExample/Sections/Pages/IM/LeanChatMessageTableViewController.m
+++ b/Example/MessageDisplayKitLeanchatExample/MessageDisplayKitLeanchatExample/Sections/Pages/IM/LeanChatMessageTableViewController.m
@@ -362,7 +362,7 @@ static NSInteger const kOnePageSize = 7;
             self.loadingMoreMessage = YES;
             XHMessage* message=self.messages[0];
             WEAKSELF
-            [self.conversation queryMessagesBeforeId:nil timestamp:[message.timestamp timeIntervalSince1970]*1000 limit:20 callback:^(NSArray *typedMessages, NSError *error) {
+            [self.conversation queryMessagesBeforeId:nil timestamp:[message.timestamp timeIntervalSince1970]*1000 limit:kOnePageSize callback:^(NSArray *typedMessages, NSError *error) {
                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                     NSMutableArray* messages=[NSMutableArray array];
                     for(AVIMTypedMessage* typedMessage in typedMessages){
@@ -374,8 +374,9 @@ static NSInteger const kOnePageSize = 7;
                         }
                     }
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        [weakSelf insertOldMessages:messages];
-                        weakSelf.loadingMoreMessage=NO;
+                        [weakSelf insertOldMessages:messages completion:^{
+                            weakSelf.loadingMoreMessage=NO;
+                        }];
                     });
                 });
             }];

--- a/Example/MessageDisplayKitLeanchatExample/MessageDisplayKitLeanchatExample/Sections/Pages/IM/LeanChatMessageTableViewController.m
+++ b/Example/MessageDisplayKitLeanchatExample/MessageDisplayKitLeanchatExample/Sections/Pages/IM/LeanChatMessageTableViewController.m
@@ -16,7 +16,7 @@
 // IM
 #import "LeanChatManager.h"
 
-static NSInteger const kOnePageSize = 10;
+static NSInteger const kOnePageSize = 7;
 
 @interface LeanChatMessageTableViewController () <XHAudioPlayerHelperDelegate>
 
@@ -212,10 +212,10 @@ static NSInteger const kOnePageSize = 10;
         default:
             break;
     }
-    if (typedMessage.ioType == AVIMMessageIOTypeIn){
-        message.bubbleMessageType = XHBubbleMessageTypeReceiving;
-    } else {
+    if ([typedMessage.clientId isEqualToString:[LeanChatManager manager].selfClientID]) {
         message.bubbleMessageType = XHBubbleMessageTypeSending;
+    } else {
+        message.bubbleMessageType = XHBubbleMessageTypeReceiving;
     }
     message.avatarUrl = [self avatarUrlByClientId:typedMessage.clientId];
     return message;

--- a/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.h
+++ b/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.h
@@ -263,7 +263,7 @@
  *  @param oldMessages 目标的旧消息数据
  *  @param completion  insert 完成回调
  */
-- (void)insertOldMessages:(NSArray *)oldMessages completion:(void (^)())completion ;
+- (void)insertOldMessages:(NSArray *)oldMessages completion:(void (^)())completion;
 
 #pragma mark - Messages view controller
 /**

--- a/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.h
+++ b/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.h
@@ -257,6 +257,14 @@
  */
 - (void)insertOldMessages:(NSArray *)oldMessages;
 
+/**
+ *  同上，增加了 completion 来通知消息插入完毕
+ *
+ *  @param oldMessages 目标的旧消息数据
+ *  @param completion  insert 完成回调
+ */
+- (void)insertOldMessages:(NSArray *)oldMessages completion:(void (^)())completion ;
+
 #pragma mark - Messages view controller
 /**
  *  完成发送消息的函数

--- a/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
+++ b/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
@@ -261,7 +261,7 @@
 
 static CGPoint  delayOffset = {0.0};
 // http://stackoverflow.com/a/11602040 Keep UITableView static when inserting rows at the top
-- (void)insertOldMessages:(NSArray *)oldMessages {
+- (void)insertOldMessages:(NSArray *)oldMessages completion:(void (^)())completion {
     WEAKSELF
     [self exChangeMessageDataSourceQueue:^{
         NSMutableArray *messages = [[NSMutableArray alloc] initWithArray:weakSelf.messages];
@@ -291,8 +291,15 @@ static CGPoint  delayOffset = {0.0};
             [UIView setAnimationsEnabled:YES];
             
             [weakSelf.messageTableView setContentOffset:delayOffset animated:NO];
+            if (completion) {
+                completion();
+            }
         }];
     }];
+}
+
+- (void)insertOldMessages:(NSArray *)oldMessages {
+    [self insertOldMessages:oldMessages completion:nil];
 }
 
 #pragma mark - Propertys


### PR DESCRIPTION
断点发现有时会同时进入 insertOldMessages:completion， 导致 tableview 刷新的时候，messages 数量发生变化，然后崩溃。

发现 以前的
[ self insertOldMessage];
loadingOldMessages = NO;

这样 setNo 的时候，其实还没 insert 完成。所以可能因为 loadingOldMessages = NO而再次触发加载。

此 PR 修改后，就不会出现这个问题了。

@xhzengAIB 