### PR TITLE
过滤普通Message，保留 AVIMTypedMessage & fix code style

### DIFF
--- a/Example/MessageDisplayKitLib/MessageDisplayKitLib.xcodeproj/project.pbxproj
+++ b/Example/MessageDisplayKitLib/MessageDisplayKitLib.xcodeproj/project.pbxproj
@@ -192,8 +192,6 @@
 		F7B9E7FB1A4D5E7B0072F81B /* FLAnimatedImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLAnimatedImageView.m; sourceTree = "<group>"; };
 		F7B9E7FD1A4D5E7B0072F81B /* LKBadgeView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LKBadgeView.h; sourceTree = "<group>"; };
 		F7B9E7FE1A4D5E7B0072F81B /* LKBadgeView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LKBadgeView.m; sourceTree = "<group>"; };
-		F7B9E8001A4D5E7B0072F81B /* NSMutableAttributedString+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableAttributedString+Helper.h"; sourceTree = "<group>"; };
-		F7B9E8011A4D5E7B0072F81B /* NSMutableAttributedString+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableAttributedString+Helper.m"; sourceTree = "<group>"; };
 		F7B9E8021A4D5E7B0072F81B /* SECompatibility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SECompatibility.h; sourceTree = "<group>"; };
 		F7B9E8031A4D5E7B0072F81B /* SECompatibility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SECompatibility.m; sourceTree = "<group>"; };
 		F7B9E8041A4D5E7B0072F81B /* SEConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEConstants.h; sourceTree = "<group>"; };
@@ -655,8 +653,6 @@
 		F7B9E7FF1A4D5E7B0072F81B /* SECoreTextView */ = {
 			isa = PBXGroup;
 			children = (
-				F7B9E8001A4D5E7B0072F81B /* NSMutableAttributedString+Helper.h */,
-				F7B9E8011A4D5E7B0072F81B /* NSMutableAttributedString+Helper.m */,
 				F7B9E8021A4D5E7B0072F81B /* SECompatibility.h */,
 				F7B9E8031A4D5E7B0072F81B /* SECompatibility.m */,
 				F7B9E8041A4D5E7B0072F81B /* SEConstants.h */,


### PR DESCRIPTION
虽然我们用的都是 TypedMessage，有些开发者可能不小心写代码测试的时候， 发送了 普通 Message  到聊天室中，普通 message 没有 mediaType 方法，所以列表展示的时候，会崩溃。此 PR 过滤了普通的 Message，保留了 AVIMTypedMessage。

同时修复一些 code style，加空格，对齐等，看自己当初的代码真的好稚嫩啊。。

@xhzengAIB 