### PR TITLE
Update XHMessageTableViewController.m

### DIFF
--- a/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
+++ b/MessageDisplayKit/Classes/Controllers/XHMessageTableViewController/XHMessageTableViewController.m
@@ -732,7 +732,7 @@ static CGPoint  delayOffset = {0.0};
     NSDate *now = [NSDate date];
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     [dateFormatter setDateFormat:@"yyyyMMddHHmmssSSS"];
-    recorderPath = [recorderPath stringByAppendingFormat:@"%@-MySound.m4a", [dateFormatter stringFromDate:now]];
+    recorderPath = [recorderPath stringByAppendingFormat:@"/%@-MySound.m4a", [dateFormatter stringFromDate:now]];
     return recorderPath;
 }
 


### PR DESCRIPTION
Library的Caches目录,添加分隔符"/"才是正确的目录.若没有则目录为/Library/Caches20160905152253540-MySound.mp3,明显少一级.此问题会造成目录下语音文件过几个小时会被系统删掉,从而无法播放.
